### PR TITLE
Get the abs patht the bash script is run

### DIFF
--- a/aws_check_integrity.sh
+++ b/aws_check_integrity.sh
@@ -38,6 +38,14 @@ else
 fi
 
 
+#########################
+## Get script abs path ##
+#########################
+
+path=$(realpath "${BASH_SOURCE:-$0}")
+dir_path=$(dirname $path)
+
+
 ########################
 ## Create log file
 ########################
@@ -94,7 +102,7 @@ function upload_s3
 			if [ "$file_size" -lt 8000000 ]; then
 				etag_value="$(md5sum "$i" | awk '{ print $1 }')"
 			else
-				etag_value="$(./s3md5/s3md5 8 "$i")"
+				etag_value="$($dir_path/s3md5/s3md5 8 "$i")"
 			fi
 
 			#################################################


### PR DESCRIPTION
I found a bit annoying the need of running the bash script in the same folder the scrips is stored.
Getting the absolute path where the folder with the script is stored adds up flexibility.
Likewise, I can run the script wherever I want, creating the .logs/ in the folder I want

